### PR TITLE
Remove [skip ci] from commit message when goldens committed

### DIFF
--- a/bin/commit-goldens.js
+++ b/bin/commit-goldens.js
@@ -29,7 +29,7 @@ function commit() {
 			return git.add('*');
 		}).then(() => {
 			console.log('Added goldens. Committing...');
-			const commitMessage = `[skip ci] Updating golden with changes made in branch ${branchName}`;
+			const commitMessage = `Updating golden with changes made in branch ${branchName}`;
 			return git.commit(commitMessage);
 		}).then((status) => {
 			console.log(status);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/visual-diff",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Visual difference utility using Mocha, Chai, Puppeteer, and PixelMatch",
   "repository": "https://github.com/BrightspaceUI/visual-diff.git",
   "publishConfig": {


### PR DESCRIPTION
The PR build status does not get updated (e.g., https://github.com/BrightspaceHypermediaComponents/activities/pull/433) if the latest commit has `[skip ci]` so I think we should remove it. Given that we want to rerun the build anyways (and manually do so) to make sure it passes after the goldens get updated, this seems fine to me. I am open to other suggestions though.