### PR TITLE
Update to use PNG.sync.read.

### DIFF
--- a/file-helper.js
+++ b/file-helper.js
@@ -117,9 +117,9 @@ class FileHelper {
 
 	getImage(path) {
 		return new Promise((resolve) => {
-			const image = fs.createReadStream(path).pipe(new PNG()).on('parsed', () => {
-				resolve(image);
-			});
+			const data = fs.readFileSync(path);
+			const image = PNG.sync.read(data);
+			resolve(image);
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/visual-diff",
-  "version": "1.1.1-beta.0",
+  "version": "1.1.1",
   "description": "Visual difference utility using Mocha, Chai, Puppeteer, and PixelMatch",
   "repository": "https://github.com/BrightspaceUI/visual-diff.git",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/visual-diff",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.0",
   "description": "Visual difference utility using Mocha, Chai, Puppeteer, and PixelMatch",
   "repository": "https://github.com/BrightspaceUI/visual-diff.git",
   "publishConfig": {


### PR DESCRIPTION
This is an attempt to avoid `Error: Unexpected end of input` when using pngjs.

>       Uncaught Error: Unexpected end of input
>       at module.exports.ChunkStream._end (node_modules/pngjs/lib/chunkstream.js:100:7)
>       at module.exports.ChunkStream._process (node_modules/pngjs/lib/chunkstream.js:203:12)
>       at module.exports.ChunkStream.end (node_modules/pngjs/lib/chunkstream.js:90:10)
>       at module.exports.ParserAsync._finished (node_modules/pngjs/lib/parser-async.js:143:8)
>       at module.exports.Parser._parseIEND (node_modules/pngjs/lib/parser.js:295:10)
>       at module.exports.ChunkStream._processRead (node_modules/pngjs/lib/chunkstream.js:174:13)
>       at module.exports.ChunkStream._process (node_modules/pngjs/lib/chunkstream.js:193:14)
>       at module.exports.ChunkStream.write (node_modules/pngjs/lib/chunkstream.js:61:8)
>       at exports.PNG.PNG.write (node_modules/pngjs/lib/png.js:93:16)
>       at ReadStream.ondata (_stream_readable.js:727:22)
>       at ReadStream.EventEmitter.emit (domain.js:475:20)
>       at addChunk (_stream_readable.js:309:12)
>       at readableAddChunk (_stream_readable.js:290:11)
>       at ReadStream.Readable.push (_stream_readable.js:224:10)
>       at internal/fs/streams.js:191:12
>       at FSReqCallback.wrapper [as oncomplete] (fs.js:470:5)

Ref: https://github.com/lukeapage/pngjs/issues/129