### PR TITLE
switching from polyserve to es-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2",
     "chai": "^4",
     "chalk": "^2.4.2",
-    "pixelmatch": "^5",
-    "polyserve": "^0.27.15"
+    "es-dev-server": "^1",
+    "pixelmatch": "^5"
   }
 }


### PR DESCRIPTION
I need to wait for `intl-messageformat` to be upgraded in [localize-behavior](https://github.com/BrightspaceUI/localize-behavior/pull/30) and [core](https://github.com/BrightspaceUI/core/pull/339), but wanted to get this up.

This switches visual-diff over to use `es-dev-server` instead of `polyserve`. It was mostly a clean switch, and the directory structure of where everything is and goes is simplified (no more `components/component-name`).