### PR TITLE
Rename token

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The visual diff test reports will be stored in Amazon S3 and the Goldens are sto
 ```shell
 travis encrypt VISUAL_DIFF_S3_ID="SECRET" --add --com
 travis encrypt VISUAL_DIFF_S3_SECRET="SECRET" --add --com
-travis encrypt GITHUB_RELEASE_TOKEN="SECRET" --add --com
+travis encrypt GITHUB_TOKEN="SECRET" --add --com
 ```
 
 2. Edit `.travis.yml` to include comments above the generated secrets, identifying what the secrets are.

--- a/bin/commit-goldens.js
+++ b/bin/commit-goldens.js
@@ -2,7 +2,8 @@
 
 const git = require('simple-git/promise')();
 
-const remote = `https://${process.env.GITHUB_RELEASE_TOKEN}@github.com/${process.env.TRAVIS_REPO_SLUG}`;
+const token = process.env.GITHUB_TOKEN || process.env.GITHUB_RELEASE_TOKEN;
+const remote = `https://${token}@github.com/${process.env.TRAVIS_REPO_SLUG}`;
 const branchName = process.env.TRAVIS_BRANCH;
 
 function commit() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/visual-diff",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Visual difference utility using Mocha, Chai, Puppeteer, and PixelMatch",
   "repository": "https://github.com/BrightspaceUI/visual-diff.git",
   "publishConfig": {


### PR DESCRIPTION
This changes the golden commit token to also support `GITHUB_TOKEN` as a name. This aligns a little better with what other tools use (like `semantic-release`) for a token name, and will allow us to only specify it once instead of multiple times with different names.