### PR TITLE
feat: check for duplicate name keys

### DIFF
--- a/visual-diff.js
+++ b/visual-diff.js
@@ -45,10 +45,10 @@ class VisualDiff {
 	constructor(name, dir, options) {
 
 		if (_testNames.includes(name)) {
-            process.stdout.write(chalk.red(`\nDuplicate name key: ${name}.  VisualDiff configuration requires a unique name.\n`));
-            process.exit(1);
-        }
-        _testNames.push(name);
+			process.stdout.write(chalk.red(`\nDuplicate name key: ${name}.  VisualDiff configuration requires a unique name.\n`));
+			process.exit(1);
+		}
+		_testNames.push(name);
 
 		this.createPage = require('./helpers/createPage');
 		this.disableAnimations = require('./helpers/disableAnimations');

--- a/visual-diff.js
+++ b/visual-diff.js
@@ -16,6 +16,7 @@ let _server;
 let _goldenUpdateCount = 0;
 let _goldenErrorCount = 0;
 let _failedReportLinks;
+const _testNames = [];
 
 before(async() => {
 	const { server } = await esDevServer.startServer(_serverOptions);
@@ -42,6 +43,12 @@ after(async() => {
 class VisualDiff {
 
 	constructor(name, dir, options) {
+
+		if (_testNames.includes(name)) {
+            process.stdout.write(chalk.red(`\nDuplicate name key: ${name}.  VisualDiff configuration requires a unique name.\n`));
+            process.exit(1);
+        }
+        _testNames.push(name);
 
 		this.createPage = require('./helpers/createPage');
 		this.disableAnimations = require('./helpers/disableAnimations');


### PR DESCRIPTION
The deletion of orphaned goldens doesn't work properly if different test files use the same name key.    Since this used to be a requirement, most places should already be setup this way and we'll just add that requirement back.