### PR TITLE
fix: Add tags for org and repo instead of combining them in RoleSessionName

### DIFF
--- a/s3-helper.js
+++ b/s3-helper.js
@@ -3,16 +3,25 @@ const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 
-const repo = process.env['GITHUB_REPOSITORY'];
+const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
 let _s3Config;
 
 async function getS3Creds() {
 	return new Promise((resolve, reject) => {
 		const timestamp = (new Date()).getTime();
-		const formattedRepo = repo.replace(/\//g, '-');
 		const params = {
 			RoleArn: 'arn:aws:iam::037018655140:role/visual-diff-githubactions-access',
-			RoleSessionName: `${formattedRepo}-visual-diff-${timestamp}`
+			RoleSessionName: `visual-diff-${timestamp}`,
+			Tags: [
+				{
+					Key: 'Org',
+					Value: owner
+				},
+				{
+					Key: 'Repo',
+					Value: repo
+				}
+			]
 		};
 
 		const sts = new AWS.STS();


### PR DESCRIPTION
`RoleSessionName` has a character limit of 64.  We don't know how long our repo names will be, so we'll add that information as tags instead, and keep the `RoleSessionName` a fixed length.