### PR TITLE
First stab at flushing out some additional examples for visual-diff.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ describe('d2l-button-icon', function() {
 
 #### Asynchronous Behaviors
 
-Components may also have asynchronous behaviors (loading data, animations, etc.) triggered by user-interaction which requires the tests to wait before taking screenshots. This is typically handled by waiting for some event using one of a couple approaches. The first uses our `oneEvent` helper.
+Components may also have asynchronous behaviors (loading data, animations, etc.) triggered by user-interaction which require the tests to wait before taking screenshots. This is typically handled by waiting for some event using one of a couple approaches. The first uses our `oneEvent` helper:
 
 ```js
 const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ describe('d2l-button-icon', function() {
 * only make screenshots as big as they need to be since larger screenshots are slower to compare
 * reset focus between tests if not reloading the page
 * name screenshots using `this.test.fullTitle()`
-* use the standard Puppeteer API for all its greatness
+* use the [standard Puppeteer API](https://pptr.dev/) for all its greatness
 
 #### Asynchronous Behaviors
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm i @brightspace-ui/visual-diff puppeteer --no-save
 
 #### Standard Setup
 
-Create a `.visual-diff.html` file containing the element to be tested.
+Create a `<my-element>.visual-diff.html` file containing the element to be tested.
 
 ```html
 <!DOCTYPE html>

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ There are two approaches for setting up visual-diff tests in RTL. The first appr
 </div>
 ```
 
-The second approach involves navigating the page using Puppeteer's `goto` API, passing a query-string parameter that is used to apply `dir="rtl"` to the document. It requires more setup, but is useful in scenarios where the many fixtures contain many elements that would all otherwise require `dir="rtl"`.
+The second approach involves navigating the page using Puppeteer's `goto` API, passing a query-string parameter that is used to apply `dir="rtl"` to the document. It requires more setup, but is useful in scenarios where many fixtures contain many elements that would all otherwise require `dir="rtl"`.
 
 ```html
 <!DOCTYPE html>

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Use Puppeteer's `setViewport` API to perform visual-diff tests with different vi
 * avoid duplicating tests unnecessarily (i.e. don't need to duplicate every test at every breakpoint)
 * always use `deviceScaleFactor: 2`
 
-#### RTL
+#### Right-to-Left (RTL)
 
 There are two approaches for setting up visual-diff tests in RTL. The first approach leverages the fact that our [RtlMixin](https://github.com/BrightspaceUI/core/blob/master/mixins/rtl-mixin.md) will honor `dir="rtl"` on elements.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Create a `<my-element>.visual-diff.html` file containing the element to be teste
 </html>
 ```
 
-Create a `.visual-diff.js` file containing the tests, using a ***unique*** name for the set.
+Create a `<my-element>.visual-diff.js` file containing the tests, using a ***unique*** name for the set.
 
 ```js
 const puppeteer = require('puppeteer');


### PR DESCRIPTION
This PR expands on the examples for visual-diff in order to give consumers more direction in terms of writing tests, including things like media-queries, animations, async behaviors, and rtl.  I don't want to spend too much time on this, since this is subject to change shortly assuming I can inject fixtures into a page, thereby simplifying some of the setup.