### PR TITLE
fix: S3 bucket path should include the owner and repo

### DIFF
--- a/s3-helper.js
+++ b/s3-helper.js
@@ -52,8 +52,8 @@ class S3Helper {
 	}
 
 	getTarget() {
-		const [, repo] = process.env['GITHUB_REPOSITORY'].split('/');
-		const target = `visual-diff.d2l.dev/screenshots/${repo}/${this.name}`;
+		const fullRepo = process.env['GITHUB_REPOSITORY'];
+		const target = `visual-diff.d2l.dev/screenshots/${fullRepo}/${this.name}`;
 		return target;
 	}
 


### PR DESCRIPTION
In https://github.com/BrightspaceUI/visual-diff/pull/33, I changed `repo` from being owner + repo to just repo.  This affected the target path below (https://github.com/BrightspaceUI/visual-diff/pull/33/files#diff-268e65a4270639d14f1c5d869fa67f1ce01beecb711faa1b87eddccd72fc5359R47), so our reports started being saved at `/screenshots/core` instead of `screenshots/BrightspaceUI/core`.  Not a huge deal, but we could theoretically have a repo of the same name in different orgs and that would cause weirdness, plus it helps to organize things.