### PR TITLE
feat: Add a "Show Only Failed Tests" button to the reports

### DIFF
--- a/visual-diff.js
+++ b/visual-diff.js
@@ -266,7 +266,7 @@ class VisualDiff {
 		const diffHtml = results.map((result) => {
 
 			return `
-				<div${result.diff.pixelsDiff === 0 ? ' success' : ''}>
+				<div${result.diff.pixelsDiff === 0 ? ' class="success"' : ''}>
 					<h2>${result.name}</h2>
 					<div class="compare">
 						${createCurrentHtml(result.current)}
@@ -295,7 +295,7 @@ class VisualDiff {
 						.label { display: flex; font-size: 0.7rem; margin-bottom: 6px; }
 						.meta { font-size: 0.7rem; margin-top: 24px; }
 						.meta > div { margin-bottom: 3px; }
-						[hide-success] [success] { display: none; }
+						.hide-success .success { display: none; }
 					</style>
 				</head>
 				<body>
@@ -306,9 +306,9 @@ class VisualDiff {
 					${createMetaHtml()}
 				</body>
 				<script>
-					const checkbox = document.querySelector('input[type="checkbox"]');
+					const checkbox = document.getElementById('hideSuccesses');
 					checkbox.addEventListener('change', function() {
-						document.body.toggleAttribute('hide-success');
+						document.body.classList.toggle('hide-success', checkbox.checked);
 					});
 				</script>
 			</html>

--- a/visual-diff.js
+++ b/visual-diff.js
@@ -266,11 +266,13 @@ class VisualDiff {
 		const diffHtml = results.map((result) => {
 
 			return `
-				<h2>${result.name}</h2>
-				<div class="compare">
-					${createCurrentHtml(result.current)}
-					${createGoldenHtml(result.golden, result.current)}
-					${createDiffHtml(result.diff, result.current, result.golden)}
+				<div${result.diff.pixelsDiff === 0 ? ' success' : ''}>
+					<h2>${result.name}</h2>
+					<div class="compare">
+						${createCurrentHtml(result.current)}
+						${createGoldenHtml(result.golden, result.current)}
+						${createDiffHtml(result.diff, result.current, result.golden)}
+					</div>
 				</div>`;
 		}).join('\n');
 
@@ -284,6 +286,8 @@ class VisualDiff {
 						h1 { font-size: 1.2rem; font-weight: 400; margin: 24px 0; }
 						h2 { font-size: 0.9rem; font-weight: 400; margin: 30px 0 18px 0; }
 						a { color: #006fbf; }
+						input { transform: scale(1.5); }
+						label { font-size: 0.9rem; }
 						.compare { display: flex; }
 						.compare > div { margin: 0 18px; }
 						.compare > div:first-child { margin: 0 18px 0 0; }
@@ -291,12 +295,22 @@ class VisualDiff {
 						.label { display: flex; font-size: 0.7rem; margin-bottom: 6px; }
 						.meta { font-size: 0.7rem; margin-top: 24px; }
 						.meta > div { margin-bottom: 3px; }
+						[hide-success] [success] { display: none; }
 					</style>
 				</head>
 				<body>
-					<h1>Visual-Diff</h1>${diffHtml}
+					<h1>Visual-Diff</h1>
+					<input id="hideSuccesses" type="checkbox"></input>
+					<label for="hideSuccesses">Show Only Failed Tests</label>
+					${diffHtml}
 					${createMetaHtml()}
 				</body>
+				<script>
+					const checkbox = document.querySelector('input[type="checkbox"]');
+					checkbox.addEventListener('change', function() {
+						document.body.toggleAttribute('hide-success');
+					});
+				</script>
 			</html>
 		`;
 


### PR DESCRIPTION
I find in long reports it can be hard to tell quickly which visual-diff tests failed because sometimes there's no diff image (if the images are different sizes, or the test is new and there is no golden) or things may be scrolled offscreen for long diffs.  Thoughts on adding a button to quickly hide the ones that are all good?

Unchecked (default):
![image](https://user-images.githubusercontent.com/13419300/115740200-96f6af80-a35c-11eb-87e0-2fdfe759b1f5.png)
Checked:
![image](https://user-images.githubusercontent.com/13419300/115740297-ac6bd980-a35c-11eb-9a28-12ec96479b16.png)
