### PR TITLE
fix: support both "__dirname" and "import.meta.url" from ESM sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ Create a `<my-element>.visual-diff.html` file containing the element to be teste
 Create a `<my-element>.visual-diff.js` file containing the tests, using a ***unique*** name for the set.
 
 ```js
-const puppeteer = require('puppeteer');
-const VisualDiff = require('visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-icon', function() {
 
-  const visualDiff = new VisualDiff('button-icon', __dirname);
+  const visualDiff = new VisualDiff('button-icon', import.meta.url);
 
   let browser, page;
 
@@ -75,7 +75,7 @@ describe('d2l-button-icon', function() {
     browser = await puppeteer.launch();
     page = await visualDiff.createPage(browser);
     await page.goto(
-      `${visualDiff.getBaseUrl()}/.../button-icon.visual-diff.html`,
+      `${visualDiff.getBaseUrl()}/path/to/component/button-icon.visual-diff.html`,
       {waitUntil: ['networkidle0', 'load']}
     );
     await page.bringToFront();
@@ -114,7 +114,7 @@ describe('d2l-button-icon', function() {
 Components may also have asynchronous behaviors (loading data, animations, etc.) triggered by user-interaction which require the tests to wait before taking screenshots. This is typically handled by waiting for some event using one of a couple approaches. The first uses our `oneEvent` helper:
 
 ```js
-const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
+import oneEvent from '@brightspace-ui/visual-diff/helpers/oneEvent.js';
 
 it('some-test', async function() {
 
@@ -191,7 +191,7 @@ Use Puppeteer's `setViewport` API to perform visual-diff tests with different vi
 
 #### Right-to-Left (RTL)
 
-There are two approaches for setting up visual-diff tests in RTL. The first approach leverages the fact that our [RtlMixin](https://github.com/BrightspaceUI/core/blob/master/mixins/rtl-mixin.md) will honor `dir="rtl"` on elements.
+There are two approaches for setting up visual-diff tests in RTL. The first approach leverages the fact that our [RtlMixin](https://github.com/BrightspaceUI/core/blob/main/mixins/rtl-mixin.md) will honor `dir="rtl"` on elements.
 
 ```html
 <div class="visual-diff">
@@ -225,7 +225,7 @@ The second approach involves navigating the page using Puppeteer's `goto` API, p
 
     before(async() => {
       await page.goto(
-        `${visualDiff.getBaseUrl()}/.../button-icon.visual-diff.html?dir=${dir}`,
+        `${visualDiff.getBaseUrl()}/path/to/component/button-icon.visual-diff.html?dir=${dir}`,
         {waitUntil: ['networkidle0', 'load']}
       );
       await page.bringToFront();

--- a/visual-diff.js
+++ b/visual-diff.js
@@ -5,6 +5,7 @@ const pixelmatch = require('pixelmatch');
 const PNG = require('pngjs').PNG;
 const FileHelper = require('./file-helper.js');
 const fs = require('fs');
+const url = require('url');
 
 const _isCI = process.env['CI'] ? true : false;
 const _isLocalTestRun = !_isCI && !process.argv.includes('--golden');
@@ -50,6 +51,18 @@ class VisualDiff {
 		}
 		_testNames.push(name);
 
+		if (dir) {
+			// "dir" can be either "__dirname" from a non-ESM source,
+			// or "import.meta.url" from an ESM source.
+			try {
+				const parentDirAsURL = new URL('.', dir);
+				dir = url.fileURLToPath(parentDirAsURL);
+			// eslint-disable-next-line no-empty
+			} catch (e) {}
+		} else {
+			dir = process.cwd();
+		}
+
 		this.createPage = require('./helpers/createPage.js');
 		this.disableAnimations = require('./helpers/disableAnimations.js');
 		this.getRect = require('./helpers/getRect.js');
@@ -58,7 +71,7 @@ class VisualDiff {
 
 		this._results = [];
 		this._hasTestFailures = false;
-		this._fs = new FileHelper(name, `${dir ? dir : process.cwd()}/screenshots`, _isCI);
+		this._fs = new FileHelper(name, `${dir}/screenshots`, _isCI);
 		this._dpr = options && options.dpr ? options.dpr : 2;
 		this._tolerance = options && options.tolerance ? options.tolerance : 0;
 


### PR DESCRIPTION
In native ESM, `__dirname` is no longer supported. Instead, `import.meta.url` provides the URL to the current file. Outside of a web context, that URL will be in the form `file://path/to/file.js`.

This change allows visual-diff to handle both a normal directory path (from `__dirname`) OR `import.meta.url` and continue to work the same in either case.

This will allow us to start converting consumers over to pass `import.meta.url` before we switch visual-diff to be full ESM, allowing for a transition period. Then once visual-diff is full ESM, we can drop support for `__dirname` as part of its major release.