### PR TITLE
Switch to native ESM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-        # mocha needs to be < 8.1, may be fixed but waiting for release
-      - dependency-name: "mocha"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ If you want to install locally for test creation and troubleshooting, run:
 npm i mocha -g
 npm i @brightspace-ui/visual-diff puppeteer --no-save
 ```
-If your visual diff tests are written as ES Modules, you'll need to install `esm` as well (everything must be installed all at once):
-```shell
-npm i @brightspace-ui/visual-diff puppeteer esm --no-save
-```
 
 ## Writing Tests
 
@@ -63,7 +59,7 @@ Create a `<my-element>.visual-diff.js` file containing the tests, using a ***uni
 
 ```js
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
+import { VisualDiff } from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-icon', function() {
 
@@ -114,7 +110,7 @@ describe('d2l-button-icon', function() {
 Components may also have asynchronous behaviors (loading data, animations, etc.) triggered by user-interaction which require the tests to wait before taking screenshots. This is typically handled by waiting for some event using one of a couple approaches. The first uses our `oneEvent` helper:
 
 ```js
-import oneEvent from '@brightspace-ui/visual-diff/helpers/oneEvent.js';
+import { oneEvent } from '@brightspace-ui/visual-diff';
 
 it('some-test', async function() {
 
@@ -143,7 +139,6 @@ it('some-test', async function() {
 
     })
   });
-
 
   const rect = await visualDiff.getRect(page, '#simple');
   await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -285,11 +280,6 @@ Because of the difference in local and CI environments, you can't commit the gol
 ```
 <path_to_test>/test/screenshots/current/
 <path_to_test>/test/screenshots/golden/
-```
-
-If your visual diff tests are written as ES Modules, you'll need to include `--require esm` in your `mocha` call:
-```shell
-mocha './test/**/*.visual-diff.js' -t 10000 --require esm
 ```
 
 ***Tips:***

--- a/helpers/createPage.js
+++ b/helpers/createPage.js
@@ -1,4 +1,4 @@
-module.exports = async(browser, options) => {
+export default async function createPage(browser, options) {
 	const page = await browser.newPage();
 	await page.emulateMediaFeatures([{
 		name: 'prefers-reduced-motion', value: 'reduce'
@@ -9,4 +9,4 @@ module.exports = async(browser, options) => {
 	}
 	await page.setViewport(viewportOptions);
 	return page;
-};
+}

--- a/helpers/disableAnimations.js
+++ b/helpers/disableAnimations.js
@@ -1,5 +1,5 @@
-module.exports = async(page) => {
+export default async function disableAnimations(page) {
 	const client = await page.target().createCDPSession();
 	await client.send('Animation.enable');
 	return client.send('Animation.setPlaybackRate', { playbackRate: 100 });
-};
+}

--- a/helpers/getRect.js
+++ b/helpers/getRect.js
@@ -1,4 +1,4 @@
-module.exports = async(page, selector, margin) => {
+export default async function getRect(page, selector, margin) {
 	margin = (margin !== undefined) ? margin : 10;
 	return page.$eval(selector, (elem, margin) => {
 		const leftMargin = (elem.offsetLeft < margin ? 0 : margin);
@@ -10,4 +10,4 @@ module.exports = async(page, selector, margin) => {
 			height: elem.offsetHeight + (topMargin * 2)
 		};
 	}, margin);
-};
+}

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,5 +1,0 @@
-export { default as createPage } from './createPage.js';
-export { default as disableAnimations } from './disableAnimations.js';
-export { default as getRect } from './getRect.js';
-export { default as oneEvent } from './oneEvent.js';
-export { default as resetFocus } from './resetFocus.js';

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,6 +1,5 @@
-module.exports = {
-	createPage: require('./createPage.js'),
-	getRect: require('./getRect.js'),
-	oneEvent: require('./oneEvent.js'),
-	resetFocus: require('./resetFocus.js')
-};
+export { default as createPage } from './createPage.js';
+export { default as disableAnimations } from './disableAnimations.js';
+export { default as getRect } from './getRect.js';
+export { default as oneEvent } from './oneEvent.js';
+export { default as resetFocus } from './resetFocus.js';

--- a/helpers/oneEvent.js
+++ b/helpers/oneEvent.js
@@ -1,7 +1,7 @@
-module.exports = (page, selector, name) => {
+export default function oneEvent(page, selector, name) {
 	return page.$eval(selector, (elem, name) => {
 		return new Promise((resolve) => {
 			elem.addEventListener(name, resolve, { once: true });
 		});
 	}, name);
-};
+}

--- a/helpers/resetFocus.js
+++ b/helpers/resetFocus.js
@@ -1,4 +1,4 @@
-module.exports = async(page) => {
+export default async function resetFocus(page) {
 	await page.evaluate(() => {
 		let elem = document.querySelector('#vd-focus');
 		if (!elem) {
@@ -10,4 +10,4 @@ module.exports = async(page) => {
 		}
 	});
 	await page.click('#vd-focus');
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
 import VisualDiff from './visual-diff.js';
 export default VisualDiff;
-export { default as createPage } from './helpers/createPage.js';
-export { default as disableAnimations } from './helpers/disableAnimations.js';
-export { default as getRect } from './helpers/getRect.js';
 export { default as oneEvent } from './helpers/oneEvent.js';
-export { default as resetFocus } from './helpers/resetFocus.js';
 export { VisualDiff as VisualDiff };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+import VisualDiff from './visual-diff.js';
+export default VisualDiff;
+export { default as createPage } from './helpers/createPage.js';
+export { default as disableAnimations } from './helpers/disableAnimations.js';
+export { default as getRect } from './helpers/getRect.js';
+export { default as oneEvent } from './helpers/oneEvent.js';
+export { default as resetFocus } from './helpers/resetFocus.js';
+export { VisualDiff as VisualDiff };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "eslint": "^7",
     "eslint-config-brightspace": "^0.16",
@@ -29,11 +30,11 @@
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
     "mocha": "^9",
-    "puppeteer": "^10"
+    "puppeteer": "^12"
   },
   "peerDependencies": {
     "mocha": "^9",
-    "puppeteer": "^10"
+    "puppeteer": "^12"
   },
   "dependencies": {
     "@web/dev-server": "^0.1",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@brightspace-ui/visual-diff",
   "version": "6.1.2",
   "description": "Visual difference utility using Mocha, Chai, Puppeteer, and PixelMatch",
+  "type": "module",
   "repository": "https://github.com/BrightspaceUI/visual-diff.git",
   "publishConfig": {
     "access": "public"
   },
-  "main": "visual-diff.js",
+  "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .js,.html",
     "test": "npm run lint"
@@ -27,18 +28,19 @@
     "eslint-plugin-import": "^2",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
-    "mocha": "^8",
+    "mocha": "^9",
     "puppeteer": "^10"
   },
   "peerDependencies": {
-    "mocha": "^8",
+    "mocha": "^9",
     "puppeteer": "^10"
   },
   "dependencies": {
+    "@web/dev-server": "^0.1",
     "aws-sdk": "^2",
     "chai": "^4",
-    "chalk": "^4",
-    "es-dev-server": "^2",
-    "pixelmatch": "^5"
+    "chalk": "^5",
+    "pixelmatch": "^5",
+    "pngjs": "^6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "lint": "eslint . --ext .js,.html",
     "test": "npm run lint"
   },
+  "exports": "./index.js",
   "files": [
     "/helpers",
     "file-helper.js",
+    "index.js",
     "s3-helper.js",
     "visual-diff.js"
   ],

--- a/s3-helper.js
+++ b/s3-helper.js
@@ -1,7 +1,7 @@
-const AWS = require('aws-sdk');
-const chalk = require('chalk');
-const fs = require('fs');
-const path = require('path');
+import AWS from 'aws-sdk';
+import chalk from 'chalk';
+import { createReadStream } from 'fs';
+import path from 'path';
 
 let _s3Config;
 
@@ -41,7 +41,7 @@ async function getS3Creds() {
 	});
 }
 
-class S3Helper {
+export class S3Helper {
 
 	constructor(name) {
 		this.name = name;
@@ -85,7 +85,7 @@ class S3Helper {
 		};
 
 		return new Promise((resolve, reject) => {
-			const fileStream = fs.createReadStream(filePath);
+			const fileStream = createReadStream(filePath);
 
 			fileStream.on('error', (err) => {
 				process.stdout.write(`\n${chalk.red(err)}`);
@@ -107,5 +107,3 @@ class S3Helper {
 	}
 
 }
-
-module.exports = S3Helper;

--- a/test/test.visual-diff.js
+++ b/test/test.visual-diff.js
@@ -1,10 +1,10 @@
-const expect = require('chai').expect;
-const puppeteer = require('puppeteer');
-const VisualDiff = require('../visual-diff.js');
+import { expect } from 'chai';
+import puppeteer from 'puppeteer';
+import VisualDiff from '../visual-diff.js';
 
 describe('visual-diff', function() {
 
-	const visualDiff = new VisualDiff('visual-diff', __dirname);
+	const visualDiff = new VisualDiff('visual-diff', import.meta.url);
 
 	let browser, page;
 

--- a/visual-diff.js
+++ b/visual-diff.js
@@ -1,9 +1,13 @@
-import { createPage, disableAnimations, getRect, oneEvent, resetFocus } from './helpers/index.js';
 import chalk from 'chalk';
+import createPage from './helpers/createPage.js';
+import disableAnimations from './helpers/disableAnimations.js';
 import { expect } from 'chai';
 import { FileHelper } from './file-helper.js';
+import getRect from './helpers/getRect.js';
+import oneEvent from './helpers/oneEvent.js';
 import pixelmatch from 'pixelmatch';
 import PNG from 'pngjs';
+import resetFocus from './helpers/resetFocus.js';
 import { startDevServer } from '@web/dev-server';
 import url from 'url';
 import { writeFileSync } from 'fs';


### PR DESCRIPTION
This updates visual-diff to be a native ES module. This will be a BREAKING CHANGE.

I was a little ambitious, and updated it to use `@web/dev-server` as well, which _seems_ to be working. ~The visual-diff CI is going to fail until we update that action to use Mocha version 9.~ Actually no it won't, since it's passing the `--require esm` flag.