### PR TITLE
Revert "chore(deps-dev): bump mocha from 9.2.2 to 10.0.0 (#66)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "eslint-plugin-import": "^2",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
-    "mocha": "^10",
+    "mocha": "^9",
     "puppeteer": "^13"
   },
   "peerDependencies": {
-    "mocha": "^10",
+    "mocha": "^9",
     "puppeteer": "^13"
   },
   "dependencies": {


### PR DESCRIPTION
This reverts commit 21ca96dac4d776a9842ddca2eeee11dbd83f0310.

We treat mocha version bumps as a breaking change for visual-diff, so reverting this and then I'll re-apply with a major bump.