### PR TITLE
Support retrying visual diff tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "^4",
     "chalk": "^5",
     "pixelmatch": "^5",
-    "pngjs": "^6"
+    "pngjs": "^6",
+    "yargs": "^17"
   }
 }


### PR DESCRIPTION
The other step to this is adding `--retries=${{ inputs.RETRIES }}` to this line https://github.com/BrightspaceUI/actions/blob/main/visual-diff/action.yml#L52 and adding `RETRIES` to the file (which I was thinking of defaulting to either 1 or 2?)

When adding `--retries` to the mocha command, it by default retries X number of times. The change here is so that when retrying, the result isn't added to results X number of times, only the last time.