### PR TITLE
Update visual-diff to return a high return code if there are orphaned goldens.

### DIFF
--- a/visual-diff.js
+++ b/visual-diff.js
@@ -54,7 +54,7 @@ after(async() => {
 	process.stdout.write('\n');
 
 	if (_goldenUpdateCount === 0 && _goldenOrphanCount > 0) {
-		// force return code if no tests are triggering updates, otherwise PR will not be opened to remove orhpahned goldens
+		// force return code if no tests are triggering updates, otherwise PR will not be opened to remove orphaned goldens
 		process.exit(1);
 	}
 });

--- a/visual-diff.js
+++ b/visual-diff.js
@@ -46,7 +46,7 @@ after(async() => {
 	}
 	process.stdout.write(chalk.green(`\n  ${chalk.green(_goldenUpdateCount)} golden(s) updated.\n`));
 	if (_goldenOrphanCount > 0) {
-		process.stdout.write(chalk.green(`\n  ${chalk.green(_goldenOrphanCount)} golden(s) orphaned.\n`));
+		process.stdout.write(chalk.yellow(`\n  ${chalk.yellow(_goldenOrphanCount)} golden(s) orphaned.\n`));
 	}
 	if (_goldenErrorCount > 0) {
 		process.stdout.write(chalk.red(`\n  ${chalk.red(_goldenErrorCount)} golden updates failed.\n`));


### PR DESCRIPTION
[US147269](https://rally1.rallydev.com/#/?detail=/userstory/675673548423&fdp=true)

This PR updates visual-diff to ensure that a high return code is returned if there are orphaned goldens but no other golden updates. Without this, a PR to remove the goldens will not be created because there are no other failures.