### PR TITLE
feat: add focusWithKeyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,12 @@ await createPage(browser, options);
 await focus(page, selector);
 
 // selects an element in the document's light-DOM and focuses it using the keyboard,
-// which will trigger the :focus-visible pseudo-class
+// which will trigger the :focus-visible (but not :focus) pseudo-class
 await focusWithKeyboard(page, selector);
+
+// selects an element in the document's light-DOM and focuses it using the mouse,
+// which will trigger the :focus (but not :focus-visible) pseudo-class
+await focusWithMouse(page, selector);
 
 // selects an element in the document's light-DOM and gets a rect object for use with screenshotAndCompare (ex. { x: 50, y: 50, width: 200, height: 100 });
 // optional margin default is 10px

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Create a `<my-element>.visual-diff.js` file containing the tests, using a ***uni
 
 ```js
 import puppeteer from 'puppeteer';
-import { focus, VisualDiff } from '@brightspace-ui/visual-diff';
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-icon', function() {
 
@@ -89,7 +89,7 @@ describe('d2l-button-icon', function() {
   });
 
   it('focus', async function() {
-    await focus(page, '#simple');
+    await focusWithKeyboard(page, '#simple');
     const rect = await visualDiff.getRect(page, '#simple');
     await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
   });
@@ -269,6 +269,10 @@ await createPage(browser, options);
 
 // selects an element in the document's light-DOM and focuses it
 await focus(page, selector);
+
+// selects an element in the document's light-DOM and focuses it using the keyboard,
+// which will trigger the :focus-visible pseudo-class
+await focusWithKeyboard(page, selector);
 
 // selects an element in the document's light-DOM and gets a rect object for use with screenshotAndCompare (ex. { x: 50, y: 50, width: 200, height: 100 });
 // optional margin default is 10px

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ await createPage(browser, options);
 await focus(page, selector);
 
 // selects an element in the document's light-DOM and focuses it using the keyboard,
-// which will trigger the :focus-visible (but not :focus) pseudo-class
+// which will trigger the :focus-visible and :focus pseudo-classes
 await focusWithKeyboard(page, selector);
 
 // selects an element in the document's light-DOM and focuses it using the mouse,

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -9,7 +9,20 @@ export default function focus(page, selector) {
 
 export async function focusWithKeyboard(page, selector) {
 	await page.keyboard.press('Tab');
-	await page.$eval(selector, (elem) => {
-		elem.focus({ focusVisible: true });
+	await page.$eval(selector, elem => elem.focus({ focusVisible: true }));
+}
+
+export async function focusWithMouse(page, selector) {
+	await page.evaluate(() => {
+		let elem = document.querySelector('#vd-focus');
+		if (!elem) {
+			elem = document.createElement('button');
+			elem.id = 'vd-focus';
+			elem.innerHTML = 'reset focus';
+			elem.style.opacity = 0;
+			document.body.insertBefore(elem, document.body.firstChild);
+		}
 	});
+	await page.click('#vd-focus');
+	await page.$eval(selector, elem => elem.focus());
 }

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,3 +1,5 @@
+import { default as resetFocus } from './resetFocus.js';
+
 export default function focus(page, selector) {
 	return page.$eval(selector, elem => {
 		return new Promise(resolve => {
@@ -13,16 +15,6 @@ export async function focusWithKeyboard(page, selector) {
 }
 
 export async function focusWithMouse(page, selector) {
-	await page.evaluate(() => {
-		let elem = document.querySelector('#vd-focus');
-		if (!elem) {
-			elem = document.createElement('button');
-			elem.id = 'vd-focus';
-			elem.innerHTML = 'reset focus';
-			elem.style.opacity = 0;
-			document.body.insertBefore(elem, document.body.firstChild);
-		}
-	});
-	await page.click('#vd-focus');
+	await resetFocus(page);
 	await page.$eval(selector, elem => elem.focus());
 }

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -6,3 +6,10 @@ export default function focus(page, selector) {
 		});
 	});
 }
+
+export async function focusWithKeyboard(page, selector) {
+	await page.keyboard.press('Tab');
+	await page.$eval(selector, (elem) => {
+		elem.focus({ focusVisible: true });
+	});
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import VisualDiff from './visual-diff.js';
 export default VisualDiff;
 export { default as createPage } from './helpers/createPage.js';
-export { default as focus, focusWithKeyboard } from './helpers/focus.js';
+export { default as focus, focusWithKeyboard, focusWithMouse } from './helpers/focus.js';
 export { default as getRect } from './helpers/getRect.js';
 export { default as oneEvent } from './helpers/oneEvent.js';
 export { default as resetFocus } from './helpers/resetFocus.js';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import VisualDiff from './visual-diff.js';
 export default VisualDiff;
 export { default as createPage } from './helpers/createPage.js';
-export { default as focus } from './helpers/focus.js';
+export { default as focus, focusWithKeyboard } from './helpers/focus.js';
 export { default as getRect } from './helpers/getRect.js';
 export { default as oneEvent } from './helpers/oneEvent.js';
 export { default as resetFocus } from './helpers/resetFocus.js';


### PR DESCRIPTION
As we add more `:focus-visible`-specific styles that don't show up during `:focus`, we need a consistent way to trigger them. This mirrors the [helper in core](https://github.com/BrightspaceUI/core/blob/main/tools/web-test-runner-helpers.js#L3), which fires a keyboard event to put the browser into "keyboard mode" and then focuses on the element.

This would replace all uses of `forceFocusVisible` in our visual-diff tests.

This leaves `focus()` in kind-of a weird place... it's essentially `focusWithMouse` at this point... not sure what to do with it.