### PR TITLE
feat: allow nested selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,17 @@ await createPage(browser, options);
 // selects an element in the document's light-DOM and focuses it
 await focus(page, selector);
 
-// selects an element in the document's light-DOM and focuses it using the keyboard,
-// which will trigger the :focus-visible and :focus pseudo-classes
-await focusWithKeyboard(page, selector);
+// selects an element in the document's light-DOM, optionally searches
+// that element's (and subsequent elements') shadow root and
+// focuses on the resulting element using the keyboard,
+// triggering the :focus-visible and :focus pseudo-classes
+await focusWithKeyboard(page, selectors);
 
-// selects an element in the document's light-DOM and focuses it using the mouse,
-// which will trigger the :focus (but not :focus-visible) pseudo-class
-await focusWithMouse(page, selector);
+// selects an element in the document's light-DOM, optionally searches
+// that element's (and subsequent elements') shadow root and
+// focuses on the resulting element using the mouse,
+// triggering the :focus (but not :focus-visible) pseudo-class
+await focusWithMouse(page, selectors);
 
 // selects an element in the document's light-DOM and gets a rect object for use with screenshotAndCompare (ex. { x: 50, y: 50, width: 200, height: 100 });
 // optional margin default is 10px

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -9,12 +9,22 @@ export default function focus(page, selector) {
 	});
 }
 
-export async function focusWithKeyboard(page, selector) {
+export async function focusWithKeyboard(page, selectors) {
+	selectors = [].concat(selectors);
 	await page.keyboard.press('Tab');
-	await page.$eval(selector, elem => elem.focus({ focusVisible: true }));
+	const first = selectors.shift();
+	await page.$eval(first, (elem, selectors) => {
+		selectors.forEach(selector => elem = elem.shadowRoot.querySelector(selector));
+		elem.focus({ focusVisible: true });
+	}, selectors);
 }
 
-export async function focusWithMouse(page, selector) {
+export async function focusWithMouse(page, selectors) {
+	selectors = [].concat(selectors);
 	await resetFocus(page);
-	await page.$eval(selector, elem => elem.focus());
+	const first = selectors.shift();
+	await page.$eval(first, (elem, selectors) => {
+		selectors.forEach(selector => elem = elem.shadowRoot.querySelector(selector));
+		elem.focus();
+	});
 }


### PR DESCRIPTION
I'm running into a few cases that need to use `focusWithKeyboard`, but they need to focus on an element inside a web component's shadow root -- not just in the root document.

This allows the provided selector to optionally be an array of selectors. When that's the case, the elements' shadow roots will be queried for each entry.