### PR TITLE
fix: use Cancel instead of Tab to avoid selecting text

### DIFF
--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -11,7 +11,7 @@ export default function focus(page, selector) {
 
 export async function focusWithKeyboard(page, selectors) {
 	selectors = [].concat(selectors);
-	await page.keyboard.press('Tab');
+	await page.keyboard.press('Cancel');
 	const first = selectors.shift();
 	await page.$eval(first, (elem, selectors) => {
 		selectors.forEach(selector => elem = elem.shadowRoot.querySelector(selector));


### PR DESCRIPTION
When we Tab to enable keyboard mode, it's causing text in inputs to get selected. That isn't quite what we intended here. Using "Cancel" instead seems to also work.